### PR TITLE
Push correctly generated version of Makefile.in

### DIFF
--- a/libxmpf/src/Makefile.in
+++ b/libxmpf/src/Makefile.in
@@ -443,7 +443,10 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-include_HEADERS = xmpf_coarray_decl.mod
+@UPPER_CASE_FALSE@include_HEADERS = xmpf_coarray_decl.mod
+
+# If compiler generates module file with upper case name
+@UPPER_CASE_TRUE@include_HEADERS = XMPF_COARRAY_DECL.mod
 XMP_INC_DIR = ../../libxmp/include
 XMPF_INC_DIR = ../include
 PPFCCOMPILE = $(FC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \


### PR DESCRIPTION
`automake` is hardly usable in the current situation of OMNI Compiler repo. The error below is raising for any `Makefile.am` files and prevent the correct generation of `Makefile.in` files. 

``` bash
F-FrontEnd/gnu_module/Makefile.am: error: required file './buildutils/depcomp' not found
F-FrontEnd/gnu_module/Makefile.am:   'automake --add-missing' can install 'depcomp'
```

This file is generated by addition of a fake `./buildutils/depcomp` file and some diff has been discarded. 
